### PR TITLE
Fix potential typo in SE98/status/24/xfm-battery-000.png

### DIFF
--- a/SE98/status/16/xfm-battery-000.png
+++ b/SE98/status/16/xfm-battery-000.png
@@ -1,1 +1,0 @@
-gpm-battery-000.png

--- a/SE98/status/16/xfpm-battery-000.png
+++ b/SE98/status/16/xfpm-battery-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/SE98/status/22/xfm-battery-000.png
+++ b/SE98/status/22/xfm-battery-000.png
@@ -1,1 +1,0 @@
-gpm-battery-000.png

--- a/SE98/status/22/xfpm-battery-000.png
+++ b/SE98/status/22/xfpm-battery-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/SE98/status/24/xfm-battery-000.png
+++ b/SE98/status/24/xfm-battery-000.png
@@ -1,1 +1,0 @@
-gpm-battery-000.png

--- a/SE98/status/24/xfpm-battery-000.png
+++ b/SE98/status/24/xfpm-battery-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/SE98/status/32/xfm-battery-000.png
+++ b/SE98/status/32/xfm-battery-000.png
@@ -1,1 +1,0 @@
-gpm-battery-000.png

--- a/SE98/status/32/xfpm-battery-000.png
+++ b/SE98/status/32/xfpm-battery-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png

--- a/SE98/status/48/xfm-battery-000.png
+++ b/SE98/status/48/xfm-battery-000.png
@@ -1,1 +1,0 @@
-gpm-battery-000.png

--- a/SE98/status/48/xfpm-battery-000.png
+++ b/SE98/status/48/xfpm-battery-000.png
@@ -1,0 +1,1 @@
+gpm-battery-000.png


### PR DESCRIPTION
Symlink says xfm instead of xfpm